### PR TITLE
Fixes __init__.py

### DIFF
--- a/pyvicon/__init__.py
+++ b/pyvicon/__init__.py
@@ -1,0 +1,1 @@
+from pyvicon.pyvicon import *


### PR DESCRIPTION
Can now import with `import pyvicon`, rather than `import pyvicon.pyvicon`.